### PR TITLE
Optimize tile scanning and make it async and non-blocking

### DIFF
--- a/src/TileCounter/SafeFireAndForgetExtensions.cs
+++ b/src/TileCounter/SafeFireAndForgetExtensions.cs
@@ -1,0 +1,16 @@
+﻿namespace TileCounter;
+
+public static class SafeFireAndForgetExtensions
+{
+    public static async void SafeFireAndForget(this Task task, Action<Exception> onException)
+    {
+        try
+        {
+            await task.ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            onException(ex);
+        }
+    }
+}

--- a/src/TileCounter/i18n/default.json
+++ b/src/TileCounter/i18n/default.json
@@ -11,6 +11,9 @@
   "toggleSelectionMode": "Toggle Selection Mode",
   "selectKey": "Select Key",
 
+  "noBackLayer": "Couldn't find the Back layer",
+  "countingTiles": "Counting Tiles...",
+
   "selectedTiles": "Selected Tiles: {{count}}",
   "harvestableTiles": "Harvestable Tiles: {{count}}",
   "dryTiles": "Dry Tiles: {{count}}",


### PR DESCRIPTION
Run ScanTiles asynchronously to avoid blocking the main thread and add a SafeFireAndForget helper for fire-and-forget calls. Prevent concurrent scans with an _isScanning guard, show a HUD message while counting, and compute map bounds from the Back layer (with an error HUD if missing). Move heavy work into Task.Run, improve diggable/terrain feature checks, and add i18n strings for new messages and errors.