### PR TITLE
Add connected-field scan and 8-way option

### DIFF
--- a/src/TileCounter/Helpers.cs
+++ b/src/TileCounter/Helpers.cs
@@ -15,55 +15,91 @@ public static class Helpers
             () => ModConfig.Instance = new ModConfig(),
             () => modHelper.WriteConfig(ModConfig.Instance));
 
+        // General
+        api.AddSectionTitle(manifest, I18n.Settings_Title_General);
+
         api.AddBoolOption(
             manifest,
             () => ModConfig.Instance.SimpleBorder,
             value => ModConfig.Instance.SimpleBorder = value,
-            I18n.SimpleBorder);
+            I18n.Settings_Option_SimpleBorder,
+            I18n.Settings_Option_SimpleBorder_Description);
+
+        api.AddBoolOption(
+            manifest,
+            () => ModConfig.Instance.EightWayScan,
+            value => ModConfig.Instance.EightWayScan = value,
+            I18n.Settings_Option_8wayScan,
+            I18n.Settings_Option_8wayScan_Description);
+
+        // HUD
+        api.AddSectionTitle(manifest, I18n.Settings_Title_Hud);
+
         api.AddBoolOption(
             manifest,
             () => ModConfig.Instance.CountSelectedTiles,
             value => ModConfig.Instance.CountSelectedTiles = value,
-            I18n.CountSelectedTiles);
+            I18n.Settings_Option_CountSelectedTiles,
+            I18n.Settings_Option_CountSelectedTiles_Description);
+
         api.AddBoolOption(
             manifest,
             () => ModConfig.Instance.CountHarvestableTiles,
             value => ModConfig.Instance.CountHarvestableTiles = value,
-            I18n.CountHarvestableTiles);
+            I18n.Settings_Option_CountHarvestableTiles,
+            I18n.Settings_Option_CountHarvestableTiles_Description);
+
         api.AddBoolOption(
             manifest,
             () => ModConfig.Instance.CountDryTiles,
             value => ModConfig.Instance.CountDryTiles = value,
-            I18n.CountDryTiles);
+            I18n.Settings_Option_CountDryTiles,
+            I18n.Settings_Option_CountDryTiles_Description);
+
         api.AddBoolOption(
             manifest,
             () => ModConfig.Instance.CountSeedableTiles,
             value => ModConfig.Instance.CountSeedableTiles = value,
-            I18n.CountSeedableTiles);
+            I18n.Settings_Option_CountSeedableTiles,
+            I18n.Settings_Option_CountSeedableTiles_Description);
+
         api.AddBoolOption(
             manifest,
             () => ModConfig.Instance.CountDiggableTiles,
             value => ModConfig.Instance.CountDiggableTiles = value,
-            I18n.CountDiggableTiles);
+            I18n.Settings_Option_CountDiggableTiles,
+            I18n.Settings_Option_CountDiggableTiles_Description);
 
-        api.AddSectionTitle(manifest, I18n.Keybinds);
+        // Keybinds
+        api.AddSectionTitle(manifest, I18n.Settings_Title_Keybinds);
+
         api.AddKeybindList(
             manifest,
             () => ModConfig.Instance.ScanLocationKeys,
             keys => ModConfig.Instance.ScanLocationKeys = keys,
-            I18n.ScanCurrentLocation);
+            I18n.Settings_Keybinds_ScanLocation,
+            I18n.Settings_Keybinds_ScanLocation_Description);
+
+        api.AddKeybindList(
+            manifest,
+            () => ModConfig.Instance.ScanConnectedKeys,
+            keys => ModConfig.Instance.ScanConnectedKeys = keys,
+            I18n.Settings_Keybinds_ScanConnected,
+            I18n.Settings_Keybinds_ScanConnected_Description);
 
         api.AddKeybindList(
             manifest,
             () => ModConfig.Instance.SelectionModeKeys,
             keys => ModConfig.Instance.SelectionModeKeys = keys,
-            I18n.ToggleSelectionMode);
+            I18n.Settings_Keybinds_ToggleSelectionMode,
+            I18n.Settings_Keybinds_ToggleSelectionMode_Description);
 
         api.AddKeybindList(
             manifest,
             () => ModConfig.Instance.SelectTileKey,
             key => ModConfig.Instance.SelectTileKey = key,
-            I18n.SelectKey);
+            I18n.Settings_Keybinds_SelectTile,
+            I18n.Settings_Keybinds_SelectTile_Description);
     }
 
     public static Vector2 GetTileInFrontOfPlayer()

--- a/src/TileCounter/IGenericModConfigMenuApi.cs
+++ b/src/TileCounter/IGenericModConfigMenuApi.cs
@@ -39,15 +39,6 @@ public interface IGenericModConfigMenuApi
     /// <param name="fieldId">The unique field ID for use with <see cref="OnFieldChanged"/>, or <c>null</c> to auto-generate a randomized ID.</param>
     void AddBoolOption(IManifest mod, Func<bool> getValue, Action<bool> setValue, Func<string> name, Func<string> tooltip = null, string fieldId = null);
 
-    /// <summary>Add a keybind at the current position in the form.</summary>
-    /// <param name="mod">The mod's manifest.</param>
-    /// <param name="getValue">Get the current value from the mod config.</param>
-    /// <param name="setValue">Set a new value in the mod config.</param>
-    /// <param name="name">The label text to show in the form.</param>
-    /// <param name="tooltip">The tooltip text shown when the cursor hovers on the field, or <c>null</c> to disable the tooltip.</param>
-    /// <param name="fieldId">The unique field ID for use with <see cref="OnFieldChanged"/>, or <c>null</c> to auto-generate a randomized ID.</param>
-    void AddKeybind(IManifest mod, Func<SButton> getValue, Action<SButton> setValue, Func<string> name, Func<string> tooltip = null, string fieldId = null);
-
     /// <summary>Add a keybind list at the current position in the form.</summary>
     /// <param name="mod">The mod's manifest.</param>
     /// <param name="getValue">Get the current value from the mod config.</param>

--- a/src/TileCounter/ModConfig.cs
+++ b/src/TileCounter/ModConfig.cs
@@ -18,6 +18,12 @@ public sealed class ModConfig
         new Keybind(SButton.LeftControl, SButton.V),
         new Keybind(SButton.ControllerY, SButton.DPadRight));
 
+    public KeybindList ScanConnectedKeys { get; set; } = new(
+        new Keybind(SButton.LeftControl, SButton.X),
+        new Keybind(SButton.ControllerY, SButton.DPadDown));
+
+    public bool EightWayScan { get; set; } = true;
+
     public KeybindList SelectionModeKeys { get; set; } = new(
         new Keybind(SButton.LeftControl, SButton.C),
         new Keybind(SButton.ControllerY, SButton.DPadUp));

--- a/src/TileCounter/ModEntry.cs
+++ b/src/TileCounter/ModEntry.cs
@@ -14,8 +14,12 @@ namespace TileCounter;
 
 public class ModEntry : Mod
 {
-    private bool _isScanning;
-    private bool _inSelectionMode;
+    private bool IsScanning => _isScanningArea || _isScanningConnectedTiles;
+    private bool _isScanningArea;
+    private bool _isScanningConnectedTiles;
+    private bool InSelectionMode => _inAreaSelectionMode || _inConnectedSelectionMode;
+    private bool _inAreaSelectionMode;
+    private bool _inConnectedSelectionMode;
     private Vector2? _selectedFirstTile;
 
     public override void Entry(IModHelper helper)
@@ -69,7 +73,7 @@ public class ModEntry : Mod
 
     private void OnRenderedWorld(object? sender, RenderedWorldEventArgs e)
     {
-        if (!_inSelectionMode || !Context.IsPlayerFree)
+        if (!InSelectionMode || !Context.IsPlayerFree)
         {
             return;
         }
@@ -97,16 +101,37 @@ public class ModEntry : Mod
         {
             ScanCurrentLocation();
         }
-        else if (ModConfig.Instance.SelectionModeKeys.JustPressed())
+        else if (ModConfig.Instance.ScanConnectedKeys.JustPressed() && !_inAreaSelectionMode)
         {
-            if (!_inSelectionMode)
+            if (!_inConnectedSelectionMode)
             {
-                _inSelectionMode = true;
+                _inConnectedSelectionMode = true;
                 Game1.playSound("breathin");
             }
             else
             {
-                _inSelectionMode = false;
+                _inConnectedSelectionMode = false;
+                Game1.playSound("breathout");
+            }
+
+            foreach (Keybind keybind in ModConfig.Instance.ScanConnectedKeys.Keybinds)
+            {
+                foreach (SButton button in keybind.Buttons)
+                {
+                    Helper.Input.Suppress(button);
+                }
+            }
+        }
+        else if (ModConfig.Instance.SelectionModeKeys.JustPressed() && !_inConnectedSelectionMode)
+        {
+            if (!_inAreaSelectionMode)
+            {
+                _inAreaSelectionMode = true;
+                Game1.playSound("breathin");
+            }
+            else
+            {
+                _inAreaSelectionMode = false;
                 _selectedFirstTile = null;
                 Game1.playSound("breathout");
             }
@@ -119,7 +144,7 @@ public class ModEntry : Mod
                 }
             }
         }
-        else if (_inSelectionMode && ModConfig.Instance.SelectTileKey.JustPressed())
+        else if (InSelectionMode && ModConfig.Instance.SelectTileKey.JustPressed())
         {
             TileClicked(Game1.wasMouseVisibleThisFrame ? Game1.currentCursorTile : Helpers.GetTileInFrontOfPlayer());
 
@@ -141,11 +166,22 @@ public class ModEntry : Mod
     private void OnReturnedToTitle(object? sender, ReturnedToTitleEventArgs e)
     {
         _selectedFirstTile = null;
-        _inSelectionMode = false;
+        _inAreaSelectionMode = false;
+        _inConnectedSelectionMode = false;
     }
 
     private void TileClicked(Vector2 tile)
     {
+        if (_inConnectedSelectionMode)
+        {
+            ScanConnectedTiles(tile).SafeFireAndForget(ex =>
+            {
+                Monitor.Log($"Error while scanning tiles: {ex}", LogLevel.Error);
+            });
+            _inConnectedSelectionMode = false;
+            return;
+        }
+
         if (_selectedFirstTile == null)
         {
             _selectedFirstTile = tile;
@@ -159,9 +195,8 @@ public class ModEntry : Mod
         else
         {
             Vector2 firstTile = _selectedFirstTile.Value;
-            _inSelectionMode = false;
+            _inAreaSelectionMode = false;
             _selectedFirstTile = null;
-            Game1.playSound("coin");
             ScanTiles(firstTile, tile).SafeFireAndForget(ex =>
             {
                 Monitor.Log($"Error while scanning tiles: {ex}", LogLevel.Error);
@@ -174,7 +209,7 @@ public class ModEntry : Mod
         Layer? backLayer = Game1.currentLocation.map.GetLayer("Back");
         if (backLayer == null)
         {
-            Game1.addHUDMessage(new HUDMessage(I18n.NoBackLayer(), HUDMessage.error_type));
+            Game1.addHUDMessage(new HUDMessage(I18n.HudMessage_Error_NoBackLayer(), HUDMessage.error_type));
             return;
         }
 
@@ -187,14 +222,14 @@ public class ModEntry : Mod
 
     private async Task ScanTiles(Vector2 pos1, Vector2 pos2)
     {
-        if (_isScanning)
+        if (IsScanning)
         {
             return;
         }
 
         try
         {
-            _isScanning = true;
+            _isScanningArea = true;
 
             int minX = (int)Math.Min(pos1.X, pos2.X);
             int maxX = (int)Math.Max(pos1.X, pos2.X);
@@ -210,7 +245,7 @@ public class ModEntry : Mod
             int diggableTiles = 0;
             int harvestableTiles = 0;
 
-            Game1.addHUDMessage(new HUDMessage(I18n.CountingTiles())
+            Game1.addHUDMessage(new HUDMessage(I18n.HudMessage_Info_CountingTiles())
             {
                 type = "TileCounter_Progress",
                 messageSubject = ItemRegistry.Create("170")
@@ -264,62 +299,167 @@ public class ModEntry : Mod
                 }
             });
 
-            for (int i = Game1.hudMessages.Count - 1; i >= 0; i--)
-            {
-                if (Game1.hudMessages[i].type?.StartsWith("TileCounter_") == true)
-                {
-                    Game1.hudMessages.RemoveAt(i);
-                }
-            }
-
-            if (ModConfig.Instance.CountSelectedTiles)
-            {
-                Game1.addHUDMessage(new HUDMessage(I18n.SelectedTiles((maxX - minX + 1) * (maxY - minY + 1)))
-                {
-                    type = "TileCounter_Selected",
-                    messageSubject = new Object("293", 1)
-                });
-            }
-
-            if (harvestableTiles > 0)
-            {
-                Game1.addHUDMessage(new HUDMessage(I18n.HarvestableTiles(harvestableTiles))
-                {
-                    type = "TileCounter_Harvestable",
-                    messageSubject = new Object("24", 1)
-                });
-            }
-
-            if (dryTiles > 0)
-            {
-                Game1.addHUDMessage(new HUDMessage(I18n.DryTiles(dryTiles))
-                {
-                    type = "TileCounter_Dry",
-                    messageSubject = new Object("407", 1)
-                });
-            }
-
-            if (seedableTiles > 0)
-            {
-                Game1.addHUDMessage(new HUDMessage(I18n.SeedableTiles(seedableTiles))
-                {
-                    type = "TileCounter_Seedable",
-                    messageSubject = new Object("472", 1)
-                });
-            }
-
-            if (diggableTiles > 0)
-            {
-                Game1.addHUDMessage(new HUDMessage(I18n.DiggableTiles(diggableTiles))
-                {
-                    type = "TileCounter_Diggable",
-                    messageSubject = new Hoe()
-                });
-            }
+            ShowCount((maxX - minX + 1) * (maxY - minY + 1), harvestableTiles, dryTiles, seedableTiles, diggableTiles);
         }
         finally
         {
-            _isScanning = false;
+            Game1.playSound("coin");
+            _isScanningArea = false;
+        }
+    }
+
+    private async Task ScanConnectedTiles(Vector2 startingTile)
+    {
+        if (IsScanning)
+        {
+            return;
+        }
+
+        Dictionary<Vector2, HoeDirt> tilledTiles = Game1.currentLocation.terrainFeatures.Pairs
+            .Where(pair => pair.Value is HoeDirt)
+            .ToDictionary(pair => pair.Key, pair => (HoeDirt)pair.Value);
+
+        if (!tilledTiles.ContainsKey(startingTile))
+        {
+            return;
+        }
+
+        try
+        {
+            _isScanningConnectedTiles = true;
+
+            int seedableTiles = 0;
+            int dryTiles = 0;
+            int harvestableTiles = 0;
+            int selectedTiles = 0;
+
+            Game1.addHUDMessage(new HUDMessage(I18n.HudMessage_Info_CountingTiles())
+            {
+                type = "TileCounter_Progress",
+                messageSubject = ItemRegistry.Create("170")
+            });
+
+            // Avoid blocking main thread
+            await Task.Run(() =>
+            {
+                HashSet<Vector2> connectedTiles = new();
+                Queue<Vector2> queue = new();
+
+                queue.Enqueue(startingTile);
+                connectedTiles.Add(startingTile);
+
+                List<Vector2> directions = new() {
+                    new(0, 1), // up
+                    new(0, -1), // down
+                    new(1, 0), // right
+                    new(-1, 0), // left
+                };
+                if (ModConfig.Instance.EightWayScan)
+                {
+                    directions.Add(new(1, 1)); // up right
+                    directions.Add(new(1, -1)); // down right
+                    directions.Add(new(-1, 1)); // up left
+                    directions.Add(new(-1, -1)); // down left
+                }
+                const CollisionMask mask = CollisionMask.Buildings | CollisionMask.Flooring | CollisionMask.Furniture
+                                           | CollisionMask.Objects | CollisionMask.LocationSpecific |
+                                           CollisionMask.TerrainFeatures;
+
+                while (queue.Count > 0)
+                {
+                    Vector2 current = queue.Dequeue();
+                    HoeDirt dirt = tilledTiles[current];
+                    if (ModConfig.Instance.CountSeedableTiles
+                        && dirt.crop == null
+                        && !Game1.currentLocation.IsTileOccupiedBy(current, mask, CollisionMask.TerrainFeatures))
+                    {
+                        seedableTiles++;
+                    }
+                    else if (ModConfig.Instance.CountHarvestableTiles && dirt.readyForHarvest())
+                    {
+                        harvestableTiles++;
+                    }
+
+                    if (ModConfig.Instance.CountDryTiles && !dirt.isWatered())
+                    {
+                        dryTiles++;
+                    }
+
+                    foreach (Vector2 direction in directions)
+                    {
+                        Vector2 next = current + direction;
+                        if (tilledTiles.ContainsKey(next) && connectedTiles.Add(next))
+                        {
+                            queue.Enqueue(next);
+                        }
+                    }
+                }
+
+                selectedTiles = connectedTiles.Count;
+            });
+
+            ShowCount(selectedTiles, harvestableTiles, dryTiles, seedableTiles);
+        }
+        finally
+        {
+            Game1.playSound("coin");
+            _isScanningConnectedTiles = false;
+        }
+    }
+
+    private void ShowCount(int selectedTiles, int harvestableTiles, int dryTiles, int seedableTiles, int diggableTiles = 0)
+    {
+        for (int i = Game1.hudMessages.Count - 1; i >= 0; i--)
+        {
+            if (Game1.hudMessages[i].type?.StartsWith("TileCounter_") == true)
+            {
+                Game1.hudMessages.RemoveAt(i);
+            }
+        }
+
+        if (ModConfig.Instance.CountSelectedTiles)
+        {
+            Game1.addHUDMessage(new HUDMessage(I18n.HudMessage_Info_SelectedTiles(selectedTiles))
+            {
+                type = "TileCounter_Selected",
+                messageSubject = new Object("293", 1)
+            });
+        }
+
+        if (harvestableTiles > 0)
+        {
+            Game1.addHUDMessage(new HUDMessage(I18n.HudMessage_Info_HarvestableTiles(harvestableTiles))
+            {
+                type = "TileCounter_Harvestable",
+                messageSubject = new Object("24", 1)
+            });
+        }
+
+        if (dryTiles > 0)
+        {
+            Game1.addHUDMessage(new HUDMessage(I18n.HudMessage_Info_DryTiles(dryTiles))
+            {
+                type = "TileCounter_Dry",
+                messageSubject = new Object("407", 1)
+            });
+        }
+
+        if (seedableTiles > 0)
+        {
+            Game1.addHUDMessage(new HUDMessage(I18n.HudMessage_Info_SeedableTiles(seedableTiles))
+            {
+                type = "TileCounter_Seedable",
+                messageSubject = new Object("472", 1)
+            });
+        }
+
+        if (diggableTiles > 0)
+        {
+            Game1.addHUDMessage(new HUDMessage(I18n.HudMessage_Info_DiggableTiles(diggableTiles))
+            {
+                type = "TileCounter_Diggable",
+                messageSubject = new Hoe()
+            });
         }
     }
 }

--- a/src/TileCounter/i18n/default.json
+++ b/src/TileCounter/i18n/default.json
@@ -1,22 +1,47 @@
 {
-  "simpleBorder": "Simple Border",
-  "countSelectedTiles": "Count Selected Tiles",
-  "countHarvestableTiles": "Count Harvestable Tiles",
-  "countDryTiles": "Count Dry Tiles",
-  "countSeedableTiles": "Count Seedable Tiles",
-  "countDiggableTiles": "Count Diggable Tiles",
+  "settings.title.general": "General Settings",
+  "settings.title.hud": "HUD Statistics",
+  "settings.title.keybinds": "Controls & Keybinds",
 
-  "keybinds": "Keybinds",
-  "scanCurrentLocation": "Scan Current Location",
-  "toggleSelectionMode": "Toggle Selection Mode",
-  "selectKey": "Select Key",
+  "settings.option.simpleBorder": "Use Minimalist Border",
+  "settings.option.simpleBorder.description": "If enabled, uses a basic colored rectangle for selection. If disabled, uses the custom textured borders.",
 
-  "noBackLayer": "Couldn't find the Back layer",
-  "countingTiles": "Counting Tiles...",
+  "settings.option.8wayScan": "Include Diagonal Connections",
+  "settings.option.8wayScan.description": "Enable 8-way connectivity for the Field Scan. If disabled, only tiles directly up, down, left, or right are counted.",
 
-  "selectedTiles": "Selected Tiles: {{count}}",
-  "harvestableTiles": "Harvestable Tiles: {{count}}",
-  "dryTiles": "Dry Tiles: {{count}}",
-  "seedableTiles": "Seedable Tiles: {{count}}",
-  "diggableTiles": "Diggable Tiles: {{count}}"
+  "settings.option.countSelectedTiles": "Show Total Area Size",
+  "settings.option.countSelectedTiles.description": "Displays the total count of all tiles within the scanned or selected area.",
+
+  "settings.option.countHarvestableTiles": "Show Harvestable Crops",
+  "settings.option.countHarvestableTiles.description": "Counts how many crops are fully grown and ready for harvest.",
+
+  "settings.option.countDryTiles": "Show Dry Soil",
+  "settings.option.countDryTiles.description": "Counts how many tilled tiles currently need watering.",
+
+  "settings.option.countSeedableTiles": "Show Empty Tilled Soil",
+  "settings.option.countSeedableTiles.description": "Counts tilled tiles that are currently empty and ready for seeds.",
+
+  "settings.option.countDiggableTiles": "Show Diggable Soil",
+  "settings.option.countDiggableTiles.description": "Counts untilled tiles that can be hoed (ignores occupied tiles).",
+
+  "settings.keybinds.scanLocation": "Scan Entire Map",
+  "settings.keybinds.scanLocation.description": "calculates statistics for every tile in your current location.",
+
+  "settings.keybinds.scanConnected": "Scan Connected Field",
+  "settings.keybinds.scanConnected.description": "Triggers a scan starting from the selected tile to find all connected tilled tiles.",
+
+  "settings.keybinds.toggleSelectionMode": "Toggle Manual Selection",
+  "settings.keybinds.toggleSelectionMode.description": "Enter or exit Selection Mode to manually select an area to scan.",
+
+  "settings.keybinds.selectTile": "Select / Confirm Tile",
+  "settings.keybinds.selectTile.description": "While in Selection Mode, use this to set your start and end points.",
+
+  "hud-message.error.noBackLayer": "Couldn't find the Back layer",
+
+  "hud-message.info.countingTiles": "Counting Tiles...",
+  "hud-message.info.selectedTiles": "Selected Tiles: {{count}}",
+  "hud-message.info.harvestableTiles": "Harvestable Crops: {{count}}",
+  "hud-message.info.dryTiles": "Dry Soil: {{count}}",
+  "hud-message.info.seedableTiles": "Seedable Soil: {{count}}",
+  "hud-message.info.diggableTiles": "Diggable Soil: {{count}}"
 }


### PR DESCRIPTION
Implement scanning of connected tilled tiles and add optional 8-way connectivity. Changes include:

- ModConfig: add ScanConnectedKeys and EightWayScan options.
- Helpers: update GenericModConfigMenu usage (section titles, option labels and tooltips) and add controls for connected-field scan.
- IGenericModConfigMenuApi: remove deprecated AddKeybind signature.
- ModEntry: refactor selection/state flags into area vs connected modes, add ScanConnectedTiles (async BFS), suppress input for keybinds, offload scanning to a background task, and consolidate HUD messaging via ShowCount. Play sounds and ensure proper scanning state handling to avoid concurrent scans.
- i18n: add new localization keys for settings, keybinds, HUD messages and descriptions.

These changes add a new scan mode to count contiguous hoed tiles, provide UI/tooltips for the new settings, and refactor HUD/message handling for clarity.